### PR TITLE
switch to openjdk21

### DIFF
--- a/com.github.reds.LogisimEvolution.yml
+++ b/com.github.reds.LogisimEvolution.yml
@@ -3,7 +3,7 @@ runtime: org.freedesktop.Platform
 runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk17
+  - org.freedesktop.Sdk.Extension.openjdk21
 command: LogisimEvolution.sh
 finish-args:
   - --socket=x11
@@ -15,13 +15,13 @@ finish-args:
 
 build-options:
   env:
-    JAVA_HOME: /usr/lib/sdk/openjdk17/
+    JAVA_HOME: /usr/lib/sdk/openjdk21/
 
 modules:
   - name: openjdk
     buildsystem: simple
     build-commands:
-      - /usr/lib/sdk/openjdk17/install.sh
+      - /usr/lib/sdk/openjdk21/install.sh
 
   - name: LogisimEvolution
     buildsystem: simple


### PR DESCRIPTION
[Version 3.9.0](https://github.com/logisim-evolution/logisim-evolution/releases/tag/v3.9.0) of logisim evolution bumped java requirment to java 21.