### PR TITLE
delete flathub.json

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-  "automerge-flathubbot-prs": true
-}


### PR DESCRIPTION
Only contained [flathub-json-automerge-enabled ](https://docs.flathub.org/docs/for-app-authors/linter/#flathub-json-automerge-enabled)which is only available for verified or extra data apps. Should fix linter/build complaints.